### PR TITLE
fetch lock

### DIFF
--- a/src/processors/peersync/PollService.ts
+++ b/src/processors/peersync/PollService.ts
@@ -31,7 +31,6 @@ class PollService {
   }
 
   async fetch(ledgerIndexMin: number, ledgerIndexMax: number) {
-    if (this._peer.node_id in this._manager.connections) { return }
     const client = new ValidationsClient(this._peer.grpc_url, this.credentials())
     const ledgerRangeRequest = new LedgerRangeRequest()
     ledgerRangeRequest.setLedgerIndexMin(ledgerIndexMin)

--- a/src/processors/peersync/PollService.ts
+++ b/src/processors/peersync/PollService.ts
@@ -31,6 +31,7 @@ class PollService {
   }
 
   async fetch(ledgerIndexMin: number, ledgerIndexMax: number) {
+    if (this._peer.node_id in this._manager.connections) { return }
     const client = new ValidationsClient(this._peer.grpc_url, this.credentials())
     const ledgerRangeRequest = new LedgerRangeRequest()
     ledgerRangeRequest.setLedgerIndexMin(ledgerIndexMin)

--- a/src/processors/peersync/index.ts
+++ b/src/processors/peersync/index.ts
@@ -17,7 +17,6 @@ const pollAllPeers = async (peerManager: PeerManager): Promise<void> => {
       if (peerManager.connections[peer.node_id]) {
         peerManager.emit('error', new Error(`Connection to peer ${peer.node_id} ${peer.grpc_url} exists`))
       } else {
-        peerManager.connections[peer.node_id] = true
         await peerManager.poll(peer)
       }
     }
@@ -27,6 +26,8 @@ const peerSync = async () => {
   const peerManager = new PeerManager()
 
   peerManager.on('poll', async (peer: IPeer) => {
+    if (peer.node_id in peerManager.connections) { return }
+    peerManager.connections[peer.node_id] = true
     const ledgerIndexMax = await xrplclient.getLedgerIndex()
     const ledgerIndexMin = ledgerIndexMax - ENV.PEERSYNC_FETCH_DEPTH
     logger.info(LOGPREFIX, `Polling ${peer.node_id} ${peer.grpc_url} [${ledgerIndexMin}..${ledgerIndexMax}]`)


### PR DESCRIPTION
Here we are making sure there is no existing connection on the listener of the 'poll' event similar to the _fetching  lock i was implementing lower down. 

This implementation uses the existing object that was put in place and moves it down one level. Reason is to be sure when this fires it only happens once. Maybe later another event fires this and that lock in its current position will be skipped.